### PR TITLE
Integrate zx2c4's pass

### DIFF
--- a/src/buildconf.py
+++ b/src/buildconf.py
@@ -142,7 +142,14 @@ variables['notmuch'] = {
 
 variables.update(read_pyconf())
 for account in variables['accounts']:
-    if not 'passwordstore' in account:
+    if 'passwordstore' in account:
+        decrypted = passwordstore.decrypt(account['passwordstore'])
+        account['email'] = decrypted['UserName']
+        if 'Name' in decrypted:
+            account['name'] = decrypted['Name']
+        if 'gmail' in account['email']:
+            account['type'] = 'gmail'
+    else:
         passfile = os.path.join('static', 'password', account['name'])
         if not os.path.exists(passfile):
             log.warn("Account %s doesn't have its password; set it on %s" %

--- a/src/buildconf.py
+++ b/src/buildconf.py
@@ -13,6 +13,7 @@ import subprocess
 from jinja2 import Environment, FileSystemLoader, contextfilter
 
 import gpgvalid
+import passwordstore
 
 logging.basicConfig(level=logging.INFO)
 os.chdir(os.path.dirname(__file__))
@@ -141,10 +142,11 @@ variables['notmuch'] = {
 
 variables.update(read_pyconf())
 for account in variables['accounts']:
-    passfile = os.path.join('static', 'password', account['name'])
-    if not os.path.exists(passfile):
-        log.warn("Account %s doesn't have its password; set it on %s" %
-                 (account['name'], passfile))
+    if not 'passwordstore' in account:
+        passfile = os.path.join('static', 'password', account['name'])
+        if not os.path.exists(passfile):
+            log.warn("Account %s doesn't have its password; set it on %s" %
+                     (account['name'], passfile))
 
 
 def mkpath(path):

--- a/src/passwordstore.py
+++ b/src/passwordstore.py
@@ -1,0 +1,27 @@
+#!/usr/bin/env python
+# -*- coding: utf-8 -*-
+
+import os
+import sys
+import gnupg
+
+def get_store_path():
+    if 'PASSWORD_STORE_DIR' in os.environ:
+        dir = os.environ['PASSWORD_STORE_DIR']
+    else:
+        dir = os.path.expanduser('~') + "/.password-store"
+    return dir
+
+def decrypt(path):
+    gpg = gnupg.GPG()
+    txt = open(get_store_path() + "/" + path + ".gpg", "rb")
+    data = gpg.decrypt_file(txt)
+    if data.status == "decryption ok":
+        content = data.data.decode('utf-8').split("\n")
+        dict = {'password': data[0]}
+        for item in data[1:]:
+            split = item.split(': ')
+            dict[split[0]] = split[1]
+        return dict
+    else:
+       raise Exception("Passphrase not supplied!")

--- a/src/passwordstore.py
+++ b/src/passwordstore.py
@@ -17,11 +17,12 @@ def decrypt(path):
     txt = open(get_store_path() + "/" + path + ".gpg", "rb")
     data = gpg.decrypt_file(txt)
     if data.status == "decryption ok":
-        content = data.data.decode('utf-8').split("\n")
-        dict = {'password': data[0]}
-        for item in data[1:]:
-            split = item.split(': ')
-            dict[split[0]] = split[1]
+        lines = data.data.decode('utf-8').split("\n")
+        dict = {'password': lines[0]}
+        for line in lines[1:]:
+            split = line.split(': ', 1)
+            if len(split) == 2:
+                dict[split[0]] = split[1]
         return dict
     else:
        raise Exception("Passphrase not supplied!")

--- a/src/requirements.txt
+++ b/src/requirements.txt
@@ -1,2 +1,3 @@
 jinja2
 notmuch
+python-gnupg


### PR DESCRIPTION
[zx2c4's `pass` ](https://www.passwordstore.org/#download) encrypt each account's details in a file with the a flexible text format.
Each file is in a `store` in a tree at a location, default being `~/.passwordstore`.

For an example I have my personal email account stored at `~/.passwordstore/mail/personal.gpg` in the following format
```
password
UserName: username
Name: first name last name
```

What I have done so far:

In `buildconf.py` check if an account needs this encryped file in `10-account.json` using the following key-value pair
```
'passwordstore': 'mail/personal'
```
If this key-value pair exist for an account then `buildconf.py` will not check for a pass file in `static` and use a function in `passwordstore.py` to decrypt the file and store each item in a dict.
Then `buildconf.py` transfer each value in the dict to `account` key in `variables` except the password.

Now what I am trying to work out how to organise the code so that, in `offlineimaprc` and `msmptrc`, for an account the line for `remotepasseval` should be:

For `offlineimaprc`
```
remotepasseval = get_pass('mail/personal')['password']
```
And for `msmptrc`
```
passwordeval python -c "import passwordstore; print passwordstore.decrypt('mail/personal')['password']" 
```

My current issue is where can I put `passwordstore.py` or how to access that script from both `buildconf.py`, `offlineimaprc` and `msmptrc`? I am not that great at importing especially for python 2.