### PR TITLE
Link sistemwide notmuch python bindings.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,3 +5,4 @@ dep/ve2/
 dep/ve3/
 *.egg-info/
 dist/
+.*.vim

--- a/build-dep
+++ b/build-dep
@@ -12,6 +12,8 @@ git submodule init
 git submodule update
 virtualenv -p $(which python2) --no-site-packages "$ve"
 virtualenv -p $(which python3) --no-site-packages "$vethree"
+py3version=$(python3 -c 'import sys; print(f"{sys.version_info.major}.{sys.version_info.minor}")')
+ln -s /usr/lib/python${py3version}/site-packages/notmuch "${vethree}/lib/python${py3version}/site-packages/"
 cd "dep/afew"
 "${pythree}" setup.py install
 cd "$base"

--- a/build-dep
+++ b/build-dep
@@ -13,8 +13,12 @@ git submodule update
 virtualenv -p $(which python2) --no-site-packages "$ve"
 virtualenv -p $(which python3) --no-site-packages "$vethree"
 py3version=$(python3 -c 'import sys; print(f"{sys.version_info.major}.{sys.version_info.minor}")')
-ln -s /usr/lib/python${py3version}/site-packages/notmuch "${vethree}/lib/python${py3version}/site-packages/"
-cd "dep/afew"
+cd "${vethree}/lib/python${py3version}/site-packages/"
+for nmdep in /usr/lib/python${py3version}/site-packages/notmuch*
+do
+    ln -s $nmdep
+done
+cd "$base/dep/afew"
 "${pythree}" setup.py install
 cd "$base"
 "${pip}" install -r src/requirements.txt


### PR DESCRIPTION
This fixes #6 (tested only with archlinux!).

Should be also forward compatible because looks for the python3 version in a clever way.