### PR TITLE
Install devel version of offlineimap.

### DIFF
--- a/build-dep
+++ b/build-dep
@@ -16,4 +16,5 @@ cd "dep/afew"
 "${pythree}" setup.py install
 cd "$base"
 "${pip}" install -r src/requirements.txt
+"${pip}" install git+https://github.com/OfflineIMAP/offlineimap.git@next
 

--- a/build-dep
+++ b/build-dep
@@ -16,5 +16,8 @@ cd "dep/afew"
 "${pythree}" setup.py install
 cd "$base"
 "${pip}" install -r src/requirements.txt
-"${pip}" install git+https://github.com/OfflineIMAP/offlineimap.git@next
+if [ ! -z ${DEVEL} ]; then
+    "${pip}" install -r src/requirements_offlineimap.txt
+    "${pip}" install git+https://github.com/OfflineIMAP/offlineimap.git@next
+fi
 

--- a/src/requirements_offlineimap.txt
+++ b/src/requirements_offlineimap.txt
@@ -1,0 +1,3 @@
+six
+gssapi[kerberos]
+portalocker[cygwin]

--- a/src/templates/offlineimaprc.jinja
+++ b/src/templates/offlineimaprc.jinja
@@ -41,6 +41,9 @@ localfolders = {{maildir}}/{{account.name}}
 [Repository {{account.name}}-remote]
 maxconnections = 3
 type = IMAP
+{% if account.reference %}
+reference = {{account.reference}}
+{% endif %}
 remoteuser = {{account.imap_user or account.email}}
 remotepasseval = get_pass('''{{account.name}}''')
 remotehost = {{account.imap_host}}


### PR DESCRIPTION
I had to configure a new email in which I needed to use the `reference` parameter in the offlineimaprc configuration section of the remote.
This led me to incur in [this](https://github.com/OfflineIMAP/offlineimap/issues/335) bug. It is solved in the `next` branch, and, also if the commit is 3 months old, on archlinux (and I suspect also in debian), the `offlineimap` package is still that from the `master` branch.

This PR addresses my problem installing the `next` branch in the `ve2` local virtualenv.

Feel free to ignore this PR, if you think it is not adequate to install a dev version.