### PR TITLE
Fix email parsing in hook

### DIFF
--- a/src/static/hooks/on-new-mail/50-notify
+++ b/src/static/hooks/on-new-mail/50-notify
@@ -16,9 +16,8 @@ source "$(readlink -f "$basedir/activate")"
 
 while read line
 do
-    echo "${line}" >&2
-    to=$(notmuch show --format=raw $line|mailparse --header To)
-    from=$(notmuch show --format=raw $line|mailparse --header From)
+    to=$(notmuch show --format=raw $line|mailparse --mail-address address --header To)
+    from=$(notmuch show --format=raw $line|mailparse --mail-address address --header From)
     sub=$(notmuch show --format=raw $line|mailparse --header Subject)
     notify-send "New mail" "<b>To:</b> ${to}\n<b>From:</b> ${from}\n<b>Sub:</b> ${sub}"
 done


### PR DESCRIPTION
The hook uses the `<b></b>` syntax to highlight the fields in the notification. This breaks in case of `From` or `To` headers with the name and the email in angle brackets, as allowed by rfc. I choose to only show the email, optionally cleaning the field.