### PR TITLE
2 fixes with love

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,7 +1,6 @@
 *.swp
 /config
 mail
-dep/ve2/
-dep/ve3/
+dep/ve/
 *.egg-info/
 dist/

--- a/build-dep
+++ b/build-dep
@@ -19,5 +19,10 @@ then
 fi
 cd "$base"
 ${pip} install -r src/requirements.txt
+if [ "z${MBDEV}" != "z" ]; then
+  ${pip} install git+https://github.com/OfflineIMAP/offlineimap3.git@next
+else
+  ${pip} install offlineimap
+fi
 
 # vim: set et ts=2 sts=0 sw=0:

--- a/build-dep
+++ b/build-dep
@@ -1,22 +1,23 @@
 #!/usr/bin/env bash
 
+if [ "z${MBDEBUG}" != "z" ]; then
+  set -x
+fi
+
 base=$(realpath $(dirname $0))
-ve="$base/dep/ve2"
-vethree="$base/dep/ve3"
+ve="$base/dep/ve"
 py="${ve}/bin/python"
-pythree="${vethree}/bin/python"
-pipthree="${vethree}/bin/pip"
-pip="${ve}/bin/pip"
+pip="${py} -m pip --use-feature=2020-resolver"
 cd "$base"
 git submodule init
 git submodule update
-virtualenv -p $(which python2) --no-site-packages "$ve"
-virtualenv -p $(which python3) --no-site-packages "$vethree"
+$(which python3) -m venv --use-feature=2020-resolver "${ve}"
 if ! which afew
 then
-    cd "dep/afew"
-    "${pythree}" setup.py install
+  cd "dep/afew"
+  "${py}" setup.py install
 fi
 cd "$base"
-"${pip}" install -r src/requirements.txt
+${pip} install -r src/requirements.txt
 
+# vim: set et ts=2 sts=0 sw=0:

--- a/build-dep
+++ b/build-dep
@@ -5,7 +5,7 @@ if [ "z${MBDEBUG}" != "z" ]; then
 fi
 
 base=$(realpath $(dirname $0))
-ve="$base/dep/ve"
+ve="$base/dep/ve3"
 py="${ve}/bin/python"
 pip="${py} -m pip --use-feature=2020-resolver"
 cd "$base"
@@ -21,10 +21,5 @@ then
 fi
 cd "$base"
 ${pip} install -r src/requirements.txt
-if [ "z${MBDEV}" != "z" ]; then
-  ${pip} install git+https://github.com/OfflineIMAP/offlineimap3.git@next
-else
-  ${pip} install offlineimap
-fi
 
 # vim: set et ts=2 sts=0 sw=0:

--- a/build-dep
+++ b/build-dep
@@ -11,7 +11,7 @@ pip="${py} -m pip --use-feature=2020-resolver"
 cd "$base"
 git submodule init
 git submodule update
-$(which python3) -m venv --use-feature=2020-resolver "${ve}"
+$(which python3) -m venv "${ve}"
 if ! which afew
 then
   cd "dep/afew"

--- a/build-dep
+++ b/build-dep
@@ -9,6 +9,8 @@ ve="$base/dep/ve"
 py="${ve}/bin/python"
 pip="${py} -m pip --use-feature=2020-resolver"
 cd "$base"
+# Clean old installations
+rm -rf $base/dep/ve{2,3}
 git submodule init
 git submodule update
 $(which python3) -m venv "${ve}"

--- a/pyvenv.cfg
+++ b/pyvenv.cfg
@@ -1,0 +1,3 @@
+home = /usr/bin
+include-system-site-packages = false
+version = 3.9.0

--- a/src/requirements.txt
+++ b/src/requirements.txt
@@ -1,3 +1,6 @@
 jinja2
 pyyaml
 toml
+# offlineimap deps
+rfc6555
+wheel

--- a/src/static/activate
+++ b/src/static/activate
@@ -1,8 +1,7 @@
 ## This is meant to be sourced by bash
 configdir=$(dirname $(realpath ${BASH_SOURCE:-$0}))
 depdir=$(realpath "$configdir/../dep")
-vebin="$depdir/ve2/bin"
-vethreebin="$depdir/ve3/bin"
+vebin="$depdir/ve/bin"
 if [ ! -d "$configdir" ]; then
 	### mabye realpath doesn't exist?
 	echo "something wrong with your paths" >&2
@@ -23,7 +22,7 @@ alias mutt="mutt -F ${configdir}/muttrc"
 alias msmtp="msmtp -C ${configdir}/msmtprc"
 alias offlineimap="offlineimap -c ${configdir}/offlineimaprc"
 alias alot="alot -c ${configdir}/alotrc"
-export PATH="${configdir}/wrappers:${configdir}/bin:$vebin:$vethreebin:$PATH"
+export PATH="${configdir}/wrappers:${configdir}/bin:$vebin:$PATH"
 
 if [ -n "$oldmailenv" ]; then
 	echo "Mail env was already active (${oldmailenv})" >&2

--- a/src/static/activate
+++ b/src/static/activate
@@ -1,7 +1,7 @@
 ## This is meant to be sourced by bash
 configdir=$(dirname $(realpath ${BASH_SOURCE:-$0}))
 depdir=$(realpath "$configdir/../dep")
-vebin="$depdir/ve/bin"
+vebin="$depdir/ve3/bin"
 if [ ! -d "$configdir" ]; then
 	### mabye realpath doesn't exist?
 	echo "something wrong with your paths" >&2

--- a/src/templates/offlineimap_utils.py.jinja
+++ b/src/templates/offlineimap_utils.py.jinja
@@ -45,6 +45,6 @@ def gmail_isfolder(folder, *args):
 
 if __name__ == '__main__':
     import sys
-    print get_pass(sys.argv[1])
+    print(get_pass(sys.argv[1]))
 
 # vim: ft=python:

--- a/src/templates/offlineimaprc.jinja
+++ b/src/templates/offlineimaprc.jinja
@@ -41,6 +41,17 @@ localfolders = {{maildir}}/{{account.name}}
 [Repository {{account.name}}-remote]
 maxconnections = 3
 type = IMAP
+{% if account.reference %}
+reference = {{account.reference}}
+# Trims off the preceeding {{account.reference}} on all the folder names.
+nametrans = lambda foldername: re.sub('^{{account.reference}}/', '', foldername)
+# Filter out the directory not to be created on the server
+# to avoid infinite loops (like with Sent)
+folderfilter = lambda foldername: foldername in [
+    '{{account.reference}}/Sent',
+    '{{account.reference}}/sent',
+    ]
+{% endif %}
 remoteuser = {{account.imap_user or account.email}}
 remotepasseval = get_pass('''{{account.name}}''')
 remotehost = {{account.imap_host}}

--- a/src/templates/offlineimaprc.jinja
+++ b/src/templates/offlineimaprc.jinja
@@ -51,6 +51,8 @@ folderfilter = lambda foldername: foldername in [
     '{{account.reference}}/Sent',
     '{{account.reference}}/sent',
     ]
+{% else %}
+folderfilter = lambda f: 'sieve' not in f.lower()
 {% endif %}
 remoteuser = {{account.imap_user or account.email}}
 remotepasseval = get_pass('''{{account.name}}''')
@@ -62,7 +64,6 @@ cert_fingerprint = {{account.imap_fingerprint}}
 sslcacertfile = /etc/ssl/certs/ca-certificates.crt
 {% endif %}
 realdelete = yes
-folderfilter = lambda f: 'sieve' not in f.lower()
 {% endif %} {# gmail/imap #}
 {%- if 'torify' in account and account.torify %}
 {%- if 'cafile' not in account %}


### PR DESCRIPTION
Ciao,

in questa PR faccio due cose:

 - Butto il supporto per python2 ed installo tutto con python3 (anche offlineimap in versione py3)
 - Aggiungo il supporto per la `reference` nella configurazione remote di offlineimap

La prima cosa va fatta :D La seconda mi serve per alcuni account che hanno un namespace fisso (`INBOX/`) con cui altrimenti `mailbundle` si rompe (ovvero si rompe `offlineimap` a fare il retrieve delle mail).

Ho aggiunto due funzionalità sceme, comandate da due variabili d'ambiente che, se settate ad un qualsiasi valore, modificano il comportamento di `build-dep`:

 - `MBDEBUG` attiva `set -x`
 - `MBDEV` installa `offlineimap3` direttamente dalla branch di sviluppo (`next`, che adesso è rotta).

Occhio: l'aut{ore,rice} di `offlineimap` è passat* a sviluppare un altro software ([imapfw](https://github.com/OfflineIMAP/imapfw)). Forse vale la pena buttargli un occhio.