### PR TITLE
Add folderfilter config option

### DIFF
--- a/src/templates/offlineimaprc.jinja
+++ b/src/templates/offlineimaprc.jinja
@@ -51,7 +51,12 @@ cert_fingerprint = {{account.imap_fingerprint}}
 sslcacertfile = /etc/ssl/certs/ca-certificates.crt
 {% endif %}
 realdelete = yes
-folderfilter = lambda f: 'sieve' not in f.lower(){% if account.folderfilter %} and f.lower() not in {{account.folderfilter}}{% endif %}
+{% if account.excludefolders_func %}
+folderfilter = {{account.excludefolders_func}}
+{% else %}
+{% set excluded_folders = account.excludefolders|default(['sieve']) %}
+folderfilter = lambda f: f.lower() not in ['{{"', '".join(excluded_folders)}}']
+{% endif %} {# folderfilterfunc #}
 {% endif %} {# gmail/imap #}
 {%- if 'torify' in account and account.torify %}
 {%- if 'cafile' not in account %}

--- a/src/templates/offlineimaprc.jinja
+++ b/src/templates/offlineimaprc.jinja
@@ -51,7 +51,7 @@ cert_fingerprint = {{account.imap_fingerprint}}
 sslcacertfile = /etc/ssl/certs/ca-certificates.crt
 {% endif %}
 realdelete = yes
-folderfilter = lambda f: 'sieve' not in f.lower()
+folderfilter = lambda f: 'sieve' not in f.lower(){% if account.folderfilter %} and f.lower() not in {{account.folderfilter}}{% endif %}
 {% endif %} {# gmail/imap #}
 {%- if 'torify' in account and account.torify %}
 {%- if 'cafile' not in account %}

--- a/src/vars/examples/00-accounts.json
+++ b/src/vars/examples/00-accounts.json
@@ -1,24 +1,26 @@
 {
-	"accounts": [
-	{
-		"name": "j0n",
-		"imap_host": "mail.autistici.org",
-		"smtp_host": "smtp.autistici.org",
-		"email": "j0ntheripper@autistici.org",
-		"smtp_fingerprint": "5E:23:4E:8B:44:7C:50:EB:ED:12:68:76:91:82:DF:57:F0:1D:57:51",
-		"imap_fingerprint": "eea375e1c67a1464ecc6c3a7e6ca9596d1c2dae5"
-	},
-	{
-		"name": "john doe",
-		"email": "john@doe.com"
-	},
-	{
-		"name": "johnny",
-		"type": "gmail",
-		"email": "johnny@gmail.com"
-	}
-	], "main_account": {
-		"name": "john doe",
-		"email": "john@doe.com"
-	}
+  "accounts": [
+    {
+      "name": "j0n",
+      "imap_host": "mail.autistici.org",
+      "smtp_host": "smtp.autistici.org",
+      "email": "j0ntheripper@autistici.org",
+      "smtp_fingerprint": "5E:23:4E:8B:44:7C:50:EB:ED:12:68:76:91:82:DF:57:F0:1D:57:51",
+      "imap_fingerprint": "eea375e1c67a1464ecc6c3a7e6ca9596d1c2dae5"
+    },
+    {
+      "name": "john doe",
+      "email": "john@doe.com"
+    },
+    {
+      "name": "johnny",
+      "type": "gmail",
+      "email": "johnny@gmail.com",
+      "folderfilter": ["this", "that", "those"]
+    }
+  ],
+  "main_account": {
+    "name": "john doe",
+    "email": "john@doe.com"
+  }
 }

--- a/src/vars/examples/00-accounts.json
+++ b/src/vars/examples/00-accounts.json
@@ -10,13 +10,14 @@
     },
     {
       "name": "john doe",
-      "email": "john@doe.com"
+      "email": "john@doe.com",
+      "excludefolders_func": "lambda f: not f.lower().startswith('archive')"
     },
     {
       "name": "johnny",
       "type": "gmail",
       "email": "johnny@gmail.com",
-      "folderfilter": ["this", "that", "those"]
+      "excludefolders": ["this", "that", "those"]
     }
   ],
   "main_account": {

--- a/src/vars/examples/00-accounts.toml
+++ b/src/vars/examples/00-accounts.toml
@@ -8,6 +8,7 @@ imap_fingerprint = "eea375e1c67a1464ecc6c3a7e6ca9596d1c2dae5"
 [[accounts]]
 name = "john doe"
 email = "john@doe.com"
+excludefolders_func = "lambda f: not f.lower().startswith('archive')"
 [accounts.extra_identities.giovannino]
 # this identity belongs to the same account as john@doe.com
 # this is sometimes called alias
@@ -17,7 +18,7 @@ email="giovannino@doe.com"
 name = "johnny"
 type = "gmail"
 email = "johnny@gmail.com"
-folderfilter = ["this", "that", "those"]
+excludefolders = ["this", "that", "those"]
 [main_account]
 name = "john doe"
 email = "john@doe.com"

--- a/src/vars/examples/00-accounts.toml
+++ b/src/vars/examples/00-accounts.toml
@@ -17,6 +17,7 @@ email="giovannino@doe.com"
 name = "johnny"
 type = "gmail"
 email = "johnny@gmail.com"
+folderfilter = ["this", "that", "those"]
 [main_account]
 name = "john doe"
 email = "john@doe.com"

--- a/src/vars/examples/00-accounts.yaml
+++ b/src/vars/examples/00-accounts.yaml
@@ -13,6 +13,10 @@ accounts:
     - name: johnny
       type: gmail
       email: johnny@gmail.com
+      folderfilter:
+        - this
+        - that
+        - those
 main_account:
     name: john doe
     email: john@doe.com

--- a/src/vars/examples/00-accounts.yaml
+++ b/src/vars/examples/00-accounts.yaml
@@ -10,10 +10,11 @@ accounts:
           eea375e1c67a1464ecc6c3a7e6ca9596d1c2dae5
     - name: john doe
       email: john@doe.com
+      excludefolders_func: "lambda f: not f.lower().startswith('archive')"
     - name: johnny
       type: gmail
       email: johnny@gmail.com
-      folderfilter:
+      excludefolders:
         - this
         - that
         - those


### PR DESCRIPTION
I need this because one of the accounts I have misbehaves. Offlineimap tries to create some default IMAP folders that should yet exist...

This PR introduces a mechanism to filter out selected folder names, adding a `folderfilter` key to the account configuration. In every configuration spec chosen (json, ini, toml) it should be a list. 