### PR TITLE
Add support for papero

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,4 @@ mail
 dep/
 *.egg-info/
 dist/
+ve/

--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,6 @@
 *.swp
 /config
 mail
-dep/ve/
+dep/
 *.egg-info/
 dist/

--- a/archlinux-deps
+++ b/archlinux-deps
@@ -1,6 +1,7 @@
 DEPS="
 mutt-kz
 notmuch
+offlineimap
 go
 git
 msmtp

--- a/archlinux-deps
+++ b/archlinux-deps
@@ -1,7 +1,8 @@
 DEPS="
 mutt-kz
 notmuch
-offlineimap
+go
+git
 msmtp
 tmux
 "

--- a/build-dep
+++ b/build-dep
@@ -14,6 +14,8 @@ rm -rf $base/dep/ve{2,3}
 git submodule init
 git submodule update
 $(which python3) -m venv "${ve}"
+
+# afew
 if ! which afew
 then
   cd "dep/afew"
@@ -21,5 +23,17 @@ then
 fi
 cd "$base"
 ${pip} install -r src/requirements.txt
+
+# papero
+PAPEROPATH="dep/papero"
+if ! [ -d $PAPEROPATH ]; then
+  git clone https://git.sr.ht/~blallo/papero $PAPEROPATH
+  cd $PAPEROPATH
+else
+  cd $PAPEROPATH
+  git pull
+fi
+go build -v -o ../ ./cli/paperod/...
+cd ../..
 
 # vim: set et ts=2 sts=0 sw=0:

--- a/build-dep
+++ b/build-dep
@@ -25,7 +25,7 @@ cd "$base"
 ${pip} install -r src/requirements.txt
 
 # papero
-PAPEROPATH="dep/papero"
+PAPEROPATH="dep/papero-src"
 if ! [ -d $PAPEROPATH ]; then
   git clone https://git.sr.ht/~blallo/papero $PAPEROPATH
   cd $PAPEROPATH
@@ -34,6 +34,7 @@ else
   git pull
 fi
 go build -v -o ../ ./cli/paperod/...
+go build -v -o ../ ./cli/papero/...
 cd ../..
 
 # vim: set et ts=2 sts=0 sw=0:

--- a/debian-deps
+++ b/debian-deps
@@ -7,6 +7,7 @@ mutt
 notmuch
 afew
 realpath
+offlineimap
 golang
 git
 msmtp

--- a/debian-deps
+++ b/debian-deps
@@ -7,7 +7,8 @@ mutt
 notmuch
 afew
 realpath
-offlineimap
+golang
+git
 msmtp
 python-notmuch
 dbacl

--- a/diff.py
+++ b/diff.py
@@ -1,0 +1,293 @@
+# -*- encoding: utf-8 -*-
+
+from __future__ import annotations
+import argparse
+from enum import Enum
+import json
+import os
+import re
+import sys
+import typing as T
+
+
+class Status(Enum):
+    ADDED = "+"
+    REMOVED = "-"
+
+    def is_added(self):
+        return self is self.ADDED
+
+    def is_removed(self):
+        return self is self.REMOVED
+
+
+class Folder(Enum):
+    NEW = "new"
+    CUR = "cur"
+
+
+class Mailfile():
+    uid: int
+    flags: T.Set[T.Text]
+
+    def __init__(self, uid: int, flags: T.Set[T.Text]) -> None:
+        self.uid = uid
+        self.flags = flags
+
+    def __eq__(self, v: Mailfile):
+        return v.uid == self.uid and v.flags == self.flags
+
+    def __lt__(self, other: Mailfile) -> bool:
+        return self.uid < other.uid
+
+    def __repr__(self) -> T.Text:
+        return f"Mailfile({','.join([str(self.uid), '' .join(self.flags)])})"
+
+    @classmethod
+    def from_filename(cls, filename: T.Text) -> Mailfile:
+        parsed = re.search(
+            r"\d+_\d+.\d+.[\w\d_\-\.]+,U=(\d+),FMD5=[\w\d]{32}(:2)?,(D?F?R?S?T?)",
+            filename,
+        )
+
+        if parsed is None:
+            raise ValueError
+
+        uid = int(parsed[1])
+        flags = set(c for c in parsed[3])
+
+        return cls(uid, flags)
+
+
+class Diff(object):
+    file: Mailfile
+    status: Status
+
+    def __init__(self, file: Mailfile, status: Status) -> None:
+        self.file = file
+        self.status = status
+
+
+class MailboxDiff(object):
+    new: T.List[Diff]
+    cur: T.List[Diff]
+
+    def __init__(self, new: T.List[Diff], cur: T.List[Diff]) -> None:
+        self.new = new
+        self.cur = cur
+
+    def __repr__(self) -> T.Text:
+        return f"MailboxDiff({len(self.new)}, {len(self.cur)})"
+
+    def _divide(
+        self, folder: Folder
+    ) -> T.Tuple[T.Dict[int, Mailfile], T.Dict[int, Mailfile]]:
+        added = dict()
+        removed = dict()
+
+        for diff in getattr(self, folder.value):
+            if diff.status.is_added():
+                added[diff.file.uid] = diff.file
+            else:
+                removed[diff.file.uid] = diff.file
+
+        return added, removed
+
+    def added(self, folder: T.Union[T.Text, Folder]) -> T.List[Mailfile]:
+        if isinstance(folder, str):
+            folder = Folder(folder)
+
+        added, removed = self._divide(folder)
+        result = []
+
+        for uid, file in added.items():
+            if uid not in removed:
+                result.append(file)
+
+        return result
+
+    def removed(self, folder: T.Union[T.Text, Folder]) -> T.List[Mailfile]:
+        if isinstance(folder, str):
+            folder = Folder(folder)
+
+        added, removed = self._divide(folder)
+        result = []
+
+        for uid, file in removed.items():
+            if uid not in added:
+                result.append(file)
+
+        return result
+
+    def changed(self, folder: T.Union[T.Text, Folder]) -> T.List[Mailfile]:
+        if isinstance(folder, str):
+            folder = Folder(folder)
+
+        added, removed = self._divide(folder)
+        result = []
+
+        for uid, file in removed.items():
+            if uid in added:
+                result.append(file)
+
+        return result
+
+
+class Mailbox(object):
+    new: T.List[Mailfile]
+    cur: T.List[Mailfile]
+
+    def __init__(self, new: T.List[Mailfile], cur: T.List[Mailfile]) -> None:
+        self.new = new
+        self.cur = cur
+
+    @staticmethod
+    def _diff(set1: T.List[Mailfile], set2: T.List[Mailfile]) -> T.List[Diff]:
+        result: T.List[Diff] = []
+
+        for el in set1:
+            try:
+                set2.remove(el)
+            except ValueError:
+                result.append(Diff(el, Status.ADDED))
+
+        for el in set2:
+            result.append(Diff(el, Status.REMOVED))
+
+        return result
+
+    def diff(self, other: Mailbox) -> MailboxDiff:
+        newdiff = self._diff(self.new, other.new)
+        curdiff = self._diff(self.cur, other.cur)
+
+        return MailboxDiff(newdiff, curdiff)
+
+    @classmethod
+    def from_path(cls, path: T.Text) -> Mailbox:
+        dirs = os.listdir(path)
+        if "cur" not in dirs or "new" not in dirs:
+            raise ValueError(f"{path} is not a maildir")
+
+        cur: T.List[Mailfile] = []
+        for file in os.listdir(os.path.join(path, "cur")):
+            try:
+                cur.append(Mailfile.from_filename(file))
+            except ValueError:
+                print(f"Skipping malformed filename {file}", file=sys.stderr)
+
+        new: T.List[Mailfile] = []
+        for file in os.listdir(os.path.join(path, "new")):
+            try:
+                new.append(Mailfile.from_filename(file))
+            except ValueError:
+                print(f"Skipping malformed filename {file}", file=sys.stderr)
+
+        return cls(new, cur)
+
+
+class MailboxEncoder(json.JSONEncoder):
+    def default(self, obj: T.Any) -> T.Any:
+        if isinstance(obj, list):
+            return [self.default(i) for i in obj]
+        if isinstance(obj, dict):
+            return dict((k, self.default(v)) for k, v in obj)
+        if isinstance(obj, Mailbox) or isinstance(obj, MailboxDiff):
+            return {
+                "new": self.default(obj.new),
+                "cur": self.default(obj.cur),
+            }
+        if isinstance(obj, Diff):
+            return {
+                "__type__": "diff",
+                "file": self.default(obj.file),
+                "diff": obj.status.value,
+            }
+        if isinstance(obj, Mailfile):
+            return {
+                "uid": obj.uid,
+                "flags": "".join(sorted(obj.flags)),
+            }
+
+        return json.JSONEncoder.default(self, obj)
+
+
+def diff(
+    path1: T.Dict[T.Text, Mailbox], path2: T.Dict[T.Text, Mailbox]
+) -> T.Dict[T.Text, MailboxDiff]:
+    result: T.Dict[T.Text, MailboxDiff] = dict()
+    mboxes1 = list(path1.keys())
+    mboxes2 = list(path2.keys())
+
+    for mbox in mboxes1:
+        try:
+            mboxes2.remove(mbox)
+            result[mbox] = path1[mbox].diff(path2[mbox])
+        except ValueError:
+            pass
+
+    for mbox in mboxes2:
+        empty = Mailbox([], [])
+        result[mbox] = empty.diff(path2[mbox])
+
+    return result
+
+
+def explore(basepath: T.Text) -> T.Dict[T.Text, Mailbox]:
+    result: T.Dict[T.Text, Mailbox] = dict()
+    for dir in os.listdir(basepath):
+        try:
+            result[dir] = Mailbox.from_path(os.path.join(basepath, dir))
+        except ValueError:
+            print(f"Skipping {dir}", file=sys.stderr)
+
+    return result
+
+
+if __name__ == "__main__":
+    parser = argparse.ArgumentParser(description="Compute the diff of two mailboxes")
+    parser.add_argument("--added", action=argparse.BooleanOptionalAction)
+    parser.add_argument("--removed", action=argparse.BooleanOptionalAction)
+    parser.add_argument("--changed", action=argparse.BooleanOptionalAction)
+    parser.add_argument("m1", metavar="MAILBOX1", help="Path to the first mailbox")
+    parser.add_argument("m2", metavar="MAILBOX2", help="Path to the second mailbox")
+
+    args = parser.parse_args()
+
+    if ((args.added and args.removed) or
+        (args.added and args.changed) or
+            (args.removed and args.changed)):
+        print(
+            "Only one (optional) flag is allowed amongst --added, --removed, --changed",
+            file=sys.stderr,
+        )
+        sys.exit(-1)
+
+    m1 = explore(args.m1)
+    m2 = explore(args.m2)
+
+    diff_result = diff(m1, m2)
+
+    result = dict()
+
+    if args.added:
+        for k, v in diff_result.items():
+            result[k] = {
+                Folder.NEW.value: v.added(Folder.NEW),
+                Folder.CUR.value: v.added(Folder.CUR),
+            }
+    elif args.removed:
+        for k, v in diff_result.items():
+            result[k] = {
+                Folder.NEW.value: v.removed(Folder.NEW),
+                Folder.CUR.value: v.removed(Folder.CUR),
+            }
+    elif args.changed:
+        for k, v in diff_result.items():
+            result[k] = {
+                Folder.NEW.value: v.changed(Folder.NEW),
+                Folder.CUR.value: v.changed(Folder.CUR),
+            }
+    else:
+        result = diff_result
+
+    print(json.dumps(result, cls=MailboxEncoder))

--- a/src/buildconf.py
+++ b/src/buildconf.py
@@ -127,7 +127,9 @@ def get_conf_files():
             raise ValueError
     for fname in files:
         if not fname[:2].isdigit():
-            log.warning("Configuration file %s does not follow sorting convention" % fname)
+            log.warning(
+                "Configuration file %s does not follow sorting convention" % fname
+            )
     return files
 
 
@@ -192,7 +194,9 @@ def get_conf():
     variables["sidebar"].setdefault(
         "additional_tags", notmuch_tags_in_sidebar(variables)
     )
-    variables["sidebar"].setdefault("tagsQuery", "date:1w.. and not tag:encrypted and tag:lists")
+    variables["sidebar"].setdefault(
+        "tagsQuery", "date:1w.. and not tag:encrypted and tag:lists"
+    )
     variables["notmuch"] = {"all_tags": all_notmuch_tags()}
     variables.update(read_pyconf())
     for account in variables["accounts"]:
@@ -222,20 +226,21 @@ def all_notmuch_tags(query="*"):
         return out.split("\n")
     return []
 
+
 def all_notmuch_tags_repeated(query="*"):
     if not (os.path.isdir("../mail/") and os.path.isdir("../mail/.notmuch/")):
         return []
 
     p = subprocess.Popen(
-        ["notmuch", "search", "--output=summary" , "--format=json", query],
+        ["notmuch", "search", "--output=summary", "--format=json", query],
         env=dict(NOTMUCH_CONFIG=os.path.normpath("../config/notmuch-config")),
         stdout=subprocess.PIPE,
     )
     out, err = p.communicate()
-    data = json.loads(out.decode('utf8'))
+    data = json.loads(out.decode("utf8"))
 
     for message in data:
-        for tag in message.get('tags', []):
+        for tag in message.get("tags", []):
             yield tag
 
 
@@ -243,13 +248,15 @@ def notmuch_tags_in_sidebar(variables):
     query = variables["sidebar"]["tagsQuery"]
     if not query:
         query = variables["search"]["defaultPeriod"]
+
     def ok_tag(tag: str) -> bool:
         if not tag.startswith("lists/"):
             return False
         # In my experience, lists with numeric names are newsletters
-        if tag.split('/', 1)[1].isdigit():
+        if tag.split("/", 1)[1].isdigit():
             return False
         return True
+
     c = collections.Counter(t for t in all_notmuch_tags_repeated(query) if ok_tag(t))
     return [tag for tag, n_occurrences in c.most_common(10)]
 

--- a/src/buildconf.py
+++ b/src/buildconf.py
@@ -11,7 +11,8 @@ import shutil
 import stat
 import subprocess
 
-from jinja2 import Environment, FileSystemLoader, contextfilter
+from jinja2 import Environment, FileSystemLoader
+from jinja2.filters import contextfilter
 
 import gpgvalid
 
@@ -53,10 +54,10 @@ def mkpath(path):
 def find(basedir):
     """find ${basedir}"""
 
-    def rel(path):
+    def rel(path: str):
         return os.path.relpath(path, basedir)
 
-    for root, dirs, filenames in os.walk(basedir):
+    for root, _, filenames in os.walk(basedir):
         yield rel(root) + os.path.sep
         for fname in filenames:
             yield rel(os.path.join(root, fname))
@@ -221,7 +222,7 @@ def all_notmuch_tags(query="*"):
             env=dict(NOTMUCH_CONFIG=os.path.normpath("../config/notmuch-config")),
             stdout=subprocess.PIPE,
         )
-        out, err = p.communicate()
+        out, _ = p.communicate()
         out = out.decode("utf8")
         return out.split("\n")
     return []
@@ -236,7 +237,7 @@ def all_notmuch_tags_repeated(query="*"):
         env=dict(NOTMUCH_CONFIG=os.path.normpath("../config/notmuch-config")),
         stdout=subprocess.PIPE,
     )
-    out, err = p.communicate()
+    out, _ = p.communicate()
     data = json.loads(out.decode("utf8"))
 
     for message in data:
@@ -258,7 +259,7 @@ def notmuch_tags_in_sidebar(variables):
         return True
 
     c = collections.Counter(t for t in all_notmuch_tags_repeated(query) if ok_tag(t))
-    return [tag for tag, n_occurrences in c.most_common(10)]
+    return [tag for tag, _ in c.most_common(10)]
 
 
 # End Notmuch }}}2

--- a/src/buildconf.py
+++ b/src/buildconf.py
@@ -12,7 +12,13 @@ import stat
 import subprocess
 
 from jinja2 import Environment, FileSystemLoader
-from jinja2.utils import pass_context
+
+try:
+    from jinja2.utils import pass_context
+except ImportError:
+    from jinja2.filters import contextfilter
+
+    pass_context = contextfilter
 
 import gpgvalid
 

--- a/src/buildconf.py
+++ b/src/buildconf.py
@@ -173,6 +173,7 @@ def get_conf():
     variables["outdir"] = os.path.realpath("../config/")
     variables["maildir"] = os.path.realpath("../mail/")
     variables["mutt_theme"] = "zenburn"
+    variables["use_offlineimap"] = True
 
     variables.update(read_conf())
     variables.setdefault("programs", {})

--- a/src/buildconf.py
+++ b/src/buildconf.py
@@ -233,8 +233,8 @@ def all_notmuch_tags_repeated(query="*"):
         return []
 
     p = subprocess.Popen(
-        ["notmuch", "search", "--output=summary", "--format=json", query],
-        env=dict(NOTMUCH_CONFIG=os.path.normpath("../config/notmuch-config")),
+        ["notmuch", "--config", os.path.normpath(
+            "../config/notmuch-config"), "search", "--output=summary", "--format=json", query],
         stdout=subprocess.PIPE,
     )
     out, _ = p.communicate()

--- a/src/buildconf.py
+++ b/src/buildconf.py
@@ -203,7 +203,7 @@ def get_conf():
     for account in variables["accounts"]:
         passfile = os.path.join("static", "password", account["name"])
         account.setdefault("fetch", True)
-        if not os.path.exists(passfile):
+        if not os.path.exists(passfile) and not account["password_exec"]:
             log.warning(
                 "Account %s doesn't have its password; set it on %s"
                 % (account["name"], passfile)

--- a/src/buildconf.py
+++ b/src/buildconf.py
@@ -12,7 +12,7 @@ import stat
 import subprocess
 
 from jinja2 import Environment, FileSystemLoader
-from jinja2.filters import contextfilter
+from jinja2.utils import pass_context
 
 import gpgvalid
 
@@ -64,19 +64,19 @@ def find(basedir):
 
 
 # Jinja {{{2
-@contextfilter
+@pass_context
 def warn(ctx, s):
     logging.getLogger("templates.%s" % ctx.name.split(".")[0]).warning(s)
     return ""
 
 
-@contextfilter
+@pass_context
 def info(ctx, s):
     logging.getLogger("templates.%s" % ctx.name.split(".")[0]).info(s)
     return ""
 
 
-@contextfilter
+@pass_context
 def debug(ctx, s):
     logging.getLogger("templates.%s" % ctx.name.split(".")[0]).debug(s)
     return ""

--- a/src/jinja/papero.toml.jinja
+++ b/src/jinja/papero.toml.jinja
@@ -1,0 +1,1 @@
+{% include "papero.toml.jinja" %}

--- a/src/static/bin/hook_each_listener
+++ b/src/static/bin/hook_each_listener
@@ -1,0 +1,21 @@
+#!/usr/bin/env bash
+
+confd=$(readlink -f $(dirname $0)/..)
+FIFO_PATH="${confd}/each.fifo"
+
+[ "$(jq -r '.use_offlineimap' ${confd}/mailbundle.json)" = "true" ] && exit 0
+
+if ! [ -p $FIFO_PATH ]; then
+    mkfifo $FIFO_PATH
+fi
+
+while true; do
+    while read new_mail; do
+        echo "[$(date)] New mail"
+        for script in "${confd}/hooks/on-new-mail/*"; do
+            $script $new_mail
+        done
+    done < $FIFO_PATH
+done
+
+# vim: set ft=sh:

--- a/src/static/bin/hook_each_listener
+++ b/src/static/bin/hook_each_listener
@@ -10,12 +10,11 @@ if ! [ -p $FIFO_PATH ]; then
 fi
 
 while true; do
-    while read new_mail; do
-        echo "[$(date)] New mail"
-        for script in "${confd}/hooks/on-new-mail/*"; do
-            $script $new_mail
-        done
-    done < $FIFO_PATH
+    mail_header=$(cat $FIFO_PATH)
+    echo "[$(date)] New mail"
+    for script in "${confd}/hooks/on-new-mail/*"; do
+        $script $mail_header
+    done
 done
 
 # vim: set ft=sh:

--- a/src/static/bin/hook_each_listener
+++ b/src/static/bin/hook_each_listener
@@ -12,9 +12,7 @@ fi
 while true; do
     mail_header=$(cat $FIFO_PATH)
     echo "[$(date)] New mail"
-    for script in "${confd}/hooks/on-new-mail/*"; do
-        $script $mail_header
-    done
+    run-parts --arg="$mail_header" "${confd}/hooks/on-new-mail/"
 done
 
 # vim: set ft=sh:

--- a/src/static/bin/hook_post_listener
+++ b/src/static/bin/hook_post_listener
@@ -11,9 +11,8 @@ fi
 
 while true; do
     echo "[$(date)] Post hook execution"
-    while read _dummy; do
-        ${confd}/bin/delivery
-    done < $FIFO_PATH
+    cat $FIFO_PATH > /dev/null
+    ${confd}/bin/delivery
 done
 
 # vim: set ft=sh:

--- a/src/static/bin/hook_post_listener
+++ b/src/static/bin/hook_post_listener
@@ -1,0 +1,19 @@
+#!/usr/bin/env bash
+
+confd=$(readlink -f $(dirname $0)/..)
+FIFO_PATH="${confd}/post.fifo"
+
+[ "$(jq -r '.use_offlineimap' ${confd}/mailbundle.json)" = "true" ] && exit 0
+
+if ! [ -p $FIFO_PATH ]; then
+    mkfifo $FIFO_PATH
+fi
+
+while true; do
+    echo "[$(date)] Post hook execution"
+    while read _dummy; do
+        ${confd}/bin/delivery
+    done < $FIFO_PATH
+done
+
+# vim: set ft=sh:

--- a/src/static/bin/hook_pre_listener
+++ b/src/static/bin/hook_pre_listener
@@ -11,9 +11,8 @@ fi
 
 while true; do
     echo "Nothing to do"
-    while read _dummy; do
-        echo "Unexpected: $_dummy"
-    done < $FIFO_PATH
+    cat $FIFO_PATH > /dev/null
+    echo "Unexpected: $_dummy"
 done
 
 # vim: set ft=sh:

--- a/src/static/bin/hook_pre_listener
+++ b/src/static/bin/hook_pre_listener
@@ -1,0 +1,19 @@
+#!/usr/bin/env bash
+
+confd=$(readlink -f $(dirname $0)/..)
+FIFO_PATH="${confd}/pre.fifo"
+
+[ "$(jq -r '.use_offlineimap' ${confd}/mailbundle.json)" = "true" ] && exit 0
+
+if ! [ -p $FIFO_PATH ]; then
+    mkfifo $FIFO_PATH
+fi
+
+while true; do
+    echo "Nothing to do"
+    while read _dummy; do
+        echo "Unexpected: $_dummy"
+    done < $FIFO_PATH
+done
+
+# vim: set ft=sh:

--- a/src/static/bin/mailparse
+++ b/src/static/bin/mailparse
@@ -6,6 +6,7 @@ from collections import OrderedDict
 from email.parser import BytesHeaderParser
 from email.utils import getaddresses
 from email.header import decode_header
+import typing as T
 
 
 def get_parser():
@@ -43,6 +44,7 @@ def really_decode_header(value) -> str:
     because the email must be entirely ASCII compatible
     '''
     values = decode_header(value)
+
     def decode_string(raw, encoding):
         if type(raw) is str:
             return raw
@@ -53,6 +55,12 @@ def really_decode_header(value) -> str:
         assert type(raw) is str
         return raw
     return ''.join(decode_string(raw, encoding) for raw, encoding in values)
+
+
+def not_empty(data: T.Optional[str]) -> bool:
+    if data is None:
+        return False
+    return data.strip() != ""
 
 
 def main():
@@ -67,18 +75,19 @@ def main():
         outdata = OrderedDict()
         for h in args.header:
             values = [really_decode_header(val) for val in
-                    header.get_all(h, [])]
+                      header.get_all(h, [])]
             if values:
                 outdata[h] = values
         if args.mail_address:
             for h in outdata:
                 parsed = getaddresses(outdata[h])
                 if args.mail_address == "address":
-                    outdata[h] = [add for name, add in parsed]
+                    outdata[h] = [add for _, add in parsed]
                 if args.mail_address == "realname":
-                    outdata[h] = [name for name, add in parsed]
+                    outdata[h] = [name for name, _ in parsed]
                 if args.mail_address == "realname-or-address":
-                    outdata[h] = [name if name else add for name, add in parsed]
+                    outdata[h] = [name if not_empty(
+                        name) else add for name, add in parsed]
 
     out(outdata, args)
 

--- a/src/static/bin/mailparse
+++ b/src/static/bin/mailparse
@@ -57,10 +57,10 @@ def really_decode_header(value) -> str:
     return ''.join(decode_string(raw, encoding) for raw, encoding in values)
 
 
-def not_empty(data: T.Optional[str]) -> bool:
+def empty(data: T.Optional[str]) -> bool:
     if data is None:
-        return False
-    return data.strip() != ""
+        return True
+    return data.strip() == ""
 
 
 def main():
@@ -86,7 +86,7 @@ def main():
                 if args.mail_address == "realname":
                     outdata[h] = [name for name, _ in parsed]
                 if args.mail_address == "realname-or-address":
-                    outdata[h] = [name if not_empty(
+                    outdata[h] = [name if not empty(
                         name) else add for name, add in parsed]
 
     out(outdata, args)

--- a/src/static/hooks/on-new-mail/50-notify
+++ b/src/static/hooks/on-new-mail/50-notify
@@ -15,11 +15,19 @@ basedir="$(readlink -f "$(dirname "$0")/../../")"
 source "$(readlink -f "$basedir/activate")"
 mailparse=(mailparse --mail-address realname)
 
-while read line
-do
-    echo "${line}" >&2
-    to=$(notmuch show --format=raw $line|"${mailparse[@]}" --header To)
-    from=$(notmuch show --format=raw $line|"${mailparse[@]}" --header From)
-    sub=$(notmuch show --format=raw $line|mailparse --header Subject)
+function parse_and_notify() {
+    to=$(echo "${1}"|"${mailparse[@]}" --header To)
+    from=$(echo "${1}"|"${mailparse[@]}" --header From)
+    sub=$(echo "${1}"|mailparse --header Subject)
     notify-send "New mail" "<b>To:</b> ${to}\n<b>From:</b> ${from}\n<b>Sub:</b> ${sub}"
-done
+}
+
+if [ "${1}" != "" ]
+then
+    parse_and_notify "${1}"
+else
+    while read line
+    do
+        parse_and_notify "$(notmuch show --format=raw $line)"
+    done
+fi

--- a/src/static/hooks/on-new-mail/50-notify
+++ b/src/static/hooks/on-new-mail/50-notify
@@ -13,7 +13,7 @@ fi
 basedir="$(readlink -f "$(dirname "$0")/../../")"
 #shellcheck source=../activate
 source "$(readlink -f "$basedir/activate")"
-mailparse=(mailparse --mail-address realname)
+mailparse=(mailparse --mail-address realname-or-address)
 
 function parse_and_notify() {
     to=$(echo "${1}"|"${mailparse[@]}" --header To)

--- a/src/static/hooks/on-new-mail/60-print
+++ b/src/static/hooks/on-new-mail/60-print
@@ -1,0 +1,65 @@
+#!/usr/bin/env bash
+
+### Colors
+# Black        0;30     Dark Gray     1;30
+# Red          0;31     Light Red     1;31
+# Green        0;32     Light Green   1;32
+# Brown/Orange 0;33     Yellow        1;33
+# Blue         0;34     Light Blue    1;34
+# Purple       0;35     Light Purple  1;35
+# Cyan         0;36     Light Cyan    1;36
+# Light Gray   0;37     White         1;37
+
+CYAN_L="\033[1;36m"
+GREEN_L="\033[1;32m"
+YELLOW="\033[1;33m"
+BLUE_L="\033[1;34m"
+ORANGE="\033[0;33m"
+BOLD="\033[1m"
+ITA="\033[3m"
+RESET="\033[0m"
+
+
+function print_separator() {
+    COLS=80
+    if which tput > /dev/null; then
+        COLS=$(tput cols)
+    fi
+    printf "%${COLS}s"|tr " " "="
+    echo
+}
+
+basedir="$(readlink -f "$(dirname "$0")/../../")"
+#shellcheck source=../activate
+source "$(readlink -f "$basedir/activate")"
+mailparse=(mailparse --mail-address realname-or-address)
+
+function parse_and_print() {
+    delivered_to=$(echo "${1}"|"${mailparse[@]}" --header Delivered-To)
+    to=$(echo "${1}"|"${mailparse[@]}" --header To)
+
+    sender=$(echo "${1}"|"${mailparse[@]}" --header Sender)
+    from=$(echo "${1}"|"${mailparse[@]}" --header From)
+
+    sub=$(echo "${1}"|mailparse --header Subject)
+
+    print_separator
+    echo -e "${CYAN_L}${BOLD}To:${RESET} ${ORANGE}${to}${RESET}"
+    [ "${delivered_to}" != "" ] && \
+        echo -e "${BLUE_L}${BOLD}Delivered-To:${RESET} ${YELLOW}${delivered_to}${RESET}"
+    echo -e "${CYAN_L}${BOLD}From:${RESET} ${ORANGE}${from}${RESET}"
+    [ "${sender}" != "" ] && \
+        echo -e "${BLUE_L}${BOLD}Sender:${RESET} ${YELLOW}${sender}${RESET}"
+    echo -e "${CYAN_L}${BOLD}Sub:${RESET} ${GREEN_L}${ITA}${sub}${RESET}"
+}
+
+if [ "${1}" != "" ]
+then
+    parse_and_print "${1}"
+else
+    while read line
+    do
+        parse_and_print "$(notmuch show --format=raw $line)"
+    done
+fi
+print_separator

--- a/src/static/wrappers/paperod
+++ b/src/static/wrappers/paperod
@@ -1,0 +1,6 @@
+#!/usr/bin/env bash
+
+PAPEROD=$(readlink -f $(dirname $0)/../../dep/paperod)
+CONF=$(readlink -f $(dirname $0)/../papero.toml)
+
+$PAPEROD -config $CONF

--- a/src/templates/msmtprc.jinja
+++ b/src/templates/msmtprc.jinja
@@ -15,7 +15,11 @@ timeout 40{# this is for timeout of connection, not for sending #}
 from {{email}}
 auth on
 user {{acc.smtp_user or acc.email}}
+{% if acc.password_exec %}
+passwordeval {{acc.password_exec}}
+{% else %}
 passwordeval cat {{confdir}}/password/{{acc.name}}
+{% endif %}
 tls_starttls on
 tls on
 port 587

--- a/src/templates/papero.toml.jinja
+++ b/src/templates/papero.toml.jinja
@@ -1,0 +1,25 @@
+{% if main_account %}
+default_account = "{{main_account.name}}"
+{% else %}
+default_account = "{{accounts|first|selectattr('name')}}"
+{% endif %}
+mailbox_path = "{{maildir}}"
+default_messages = 100
+
+{% for account in accounts %}
+[[account]]
+name = "{{account.name}}"
+excluded_folders = {{account.excluded_folders}}
+    [account.connection]
+    hostname = "{{account.imap_host}}"
+    port = {{account.port|default(993)}}
+    username = "{{account.email}}"
+    {% if account.password -%}
+    password = "{{account.password}}"
+    {% elif account.password_exec -%}
+    password_exec = "{{account.password_exec}}"
+    {% endif %}
+    {% if account.proxy %}
+    proxy = "{{account.proxy}}"
+    {% endif %}
+{% endfor %}

--- a/src/templates/papero.toml.jinja
+++ b/src/templates/papero.toml.jinja
@@ -10,6 +10,7 @@ default_messages = 100
 [[account]]
 name = "{{account.name}}"
 excluded_folders = {{account.excluded_folders | default([])}}
+post_hook = "{{confdir}}/bin/delivery"
     [account.connection]
     hostname = "{{account.imap_host}}"
     port = {{account.port|default(993)}}

--- a/src/templates/papero.toml.jinja
+++ b/src/templates/papero.toml.jinja
@@ -9,7 +9,7 @@ default_messages = 100
 {% for account in accounts %}
 [[account]]
 name = "{{account.name}}"
-excluded_folders = {{account.excluded_folders}}
+excluded_folders = {{account.excluded_folders | default([])}}
     [account.connection]
     hostname = "{{account.imap_host}}"
     port = {{account.port|default(993)}}

--- a/src/templates/papero.toml.jinja
+++ b/src/templates/papero.toml.jinja
@@ -10,7 +10,8 @@ default_messages = 0
 [[account]]
 name = "{{account.name}}"
 excluded_folders = {{account.excluded_folders | default([])}}
-post_hook = "{{confdir}}/bin/delivery"
+each_hook = "{{confdir}}/each.fifo"
+post_hook = "{{confdir}}/post.fifo"
     [account.connection]
     hostname = "{{account.imap_host}}"
     port = {{account.port|default(993)}}

--- a/src/templates/papero.toml.jinja
+++ b/src/templates/papero.toml.jinja
@@ -4,7 +4,7 @@ default_account = "{{main_account.name}}"
 default_account = "{{accounts|first|selectattr('name')}}"
 {% endif %}
 mailbox_path = "{{maildir}}"
-default_messages = 100
+default_messages = 0
 
 {% for account in accounts %}
 [[account]]

--- a/src/templates/tmux.jinja
+++ b/src/templates/tmux.jinja
@@ -14,10 +14,15 @@ set-environment -g TERM screen-256color
 
 bind-key -n M-m new-window -n "new mail" mutt -s nosubject
 
-new-window {{confdir}}/bin/outmail
 {%- if use_offlineimap %}
+new-window {{confdir}}/bin/outmail
 split-window -p 50 {{confdir}}/bin/getmail
 {%- else %}
+new-window {{confdir}}/bin/hook_each_listener
+split-window -h -p 50 {{confdir}}/bin/hook_pre_listener
+split-window -v -p 50 {{confdir}}/bin/hook_post_listener
+
+new-window {{confdir}}/bin/outmail
 split-window -p 50 {{confdir}}/wrappers/paperod
 {%- endif %}
 new-window {{confdir}}/wrappers/mutt

--- a/src/templates/tmux.jinja
+++ b/src/templates/tmux.jinja
@@ -15,7 +15,7 @@ set-environment -g TERM screen-256color
 bind-key -n M-m new-window -n "new mail" mutt -s nosubject
 
 new-window {{confdir}}/bin/outmail
-split-window -p 50 {{confdir}}/bin/getmail
+split-window -p 50 {{confdir}}/wrappers/paperod
 new-window {{confdir}}/wrappers/mutt
 
 # vim: set ft=tmux:

--- a/src/templates/tmux.jinja
+++ b/src/templates/tmux.jinja
@@ -15,7 +15,11 @@ set-environment -g TERM screen-256color
 bind-key -n M-m new-window -n "new mail" mutt -s nosubject
 
 new-window {{confdir}}/bin/outmail
+{%- if use_offlineimap %}
+split-window -p 50 {{confdir}}/bin/getmail
+{%- else %}
 split-window -p 50 {{confdir}}/wrappers/paperod
+{%- endif %}
 new-window {{confdir}}/wrappers/mutt
 
 # vim: set ft=tmux:


### PR DESCRIPTION
This PR add support for using [papero](https://git.sr.ht/~blallo/papero) instead of OfflineIMAP. The reason behind this is the fact that I was unable to run OfflineIMAP with python3, and I took the chance to reimplement it in golang.
It appears to be working and have feature parity with the previous setting, but feel free to compare.